### PR TITLE
Update versions for rust, ghc, stack and protoc.

### DIFF
--- a/.github/workflows/release-base.yaml
+++ b/.github/workflows/release-base.yaml
@@ -9,9 +9,9 @@ jobs:
     with:
       SERVICE_NAME: "base"
       BUILD_ARGS: |
-        RUST_VERSION=1.74.1
-        GHC_VERSION=9.6.4
-        PROTOC_VERSION=3.15.3
+        RUST_VERSION=1.82
+        GHC_VERSION=9.6.6
+        PROTOC_VERSION=28.3
         FLATBUFFERS_TAG=v22.12.06
         NVM_SH_VERSION=v0.37.2
         CMAKE_VERSION=3.25.1

--- a/.github/workflows/release-static-libraries.yaml
+++ b/.github/workflows/release-static-libraries.yaml
@@ -10,9 +10,9 @@ jobs:
       SERVICE_NAME: "static-libraries"
       BUILD_ARGS: |
         UBUNTU_VERSION=20.04
-        RUST_VERSION=1.74.1
-        GHC_VERSION=9.6.4
-        STACK_VERSION=2.13.1
-        PROTOC_VERSION=3.15.3
+        RUST_VERSION=1.82
+        GHC_VERSION=9.6.6
+        STACK_VERSION=3.1.1
+        PROTOC_VERSION=28.3
       DOCKER_FILE_PATH: docker/static-libraries.Dockerfile
     secrets: inherit


### PR DESCRIPTION
## Purpose

Update tooling to GHC 9.6.6 and Rust 1.82.

## Changes

- GHC 9.6.6
- Stack 3.1.1
- Rust 1.82
- Protoc 28.3

## Checklist

- [X] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
