### PR TITLE
Use bullseye base image for fpic ghc build.

### DIFF
--- a/docker/linux-fpic-ghc.Dockerfile
+++ b/docker/linux-fpic-ghc.Dockerfile
@@ -1,7 +1,7 @@
 # BOOTSTRAP_GHC_VERSION corresponds to the version of GHC that we are using to build ghc.
 ARG BOOTSTRAP_GHC_VERSION
 
-FROM haskell:${BOOTSTRAP_GHC_VERSION}-buster
+FROM haskell:${BOOTSTRAP_GHC_VERSION}-bullseye
 
 RUN apt-get update || \
         apt-get upgrade -y && \


### PR DESCRIPTION
## Purpose

Since `buster` is out of LTS, it's no longer usable for building the fpic GHC. Instead, we use a `bullseye` base image.