### PR TITLE
Install python3 for building fpic ghc.

### DIFF
--- a/docker/linux-fpic-ghc.Dockerfile
+++ b/docker/linux-fpic-ghc.Dockerfile
@@ -5,7 +5,7 @@ FROM haskell:${BOOTSTRAP_GHC_VERSION}-bullseye
 
 RUN apt-get update || \
         apt-get upgrade -y && \
-        apt-get install -y libtool make m4 pkgconf autoconf automake curl libgmp-dev libncurses5-dev libtinfo6 build-essential
+        apt-get install -y libtool make m4 pkgconf autoconf automake curl libgmp-dev libncurses5-dev libtinfo6 build-essential python3
 
 COPY scripts/linux-fpic-ghc.sh /linux-fpic-ghc.sh
 RUN chmod +x /linux-fpic-ghc.sh


### PR DESCRIPTION
## Purpose

Building GHC 9.10.2 apparently requires `python3`, so we add it to the docker image.