### PR TITLE
Use bookworm for the base docker image.

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -3,11 +3,13 @@ ARG GHC_VERSION=9.10.2
 # FROM haskell:${GHC_VERSION}
 
 ### BEGIN WORKAROUND ###
-# Since currently there is no haskell image with GHC 9.10.2, we use debian bullseye as base image.
+# Since currently there is no haskell image with GHC 9.10.2, we use debian bookworm as base image.
 # This is a workaround until the haskell image is updated. This is based on how the haskell image
 # is built. (See: https://github.com/haskell/docker-haskell/blob/master/9.10/bullseye/Dockerfile)
+# Note that bookworm supports postgresql 15, whereas bullseye supports version 13, which is too
+# old for the LTS-24.0 dependencies (required by the wallet-proxy).
 
-FROM debian:bullseye
+FROM debian:bookworm
 
 
 ENV LANG=C.UTF-8


### PR DESCRIPTION
## Purpose

Addresses [COR-1660](https://linear.app/concordium/issue/COR-1660/decide-on-the-way-forward-for-postgresql-version)

This switches the base image to `debian:bookworm` to support a more recent version of PostgreSQL which is required by updated Haskell libraries in lts-24.0.
