### PR TITLE
fix: allow pushing both latest and specific tag

### DIFF
--- a/.github/workflows/activate-docker-distribution.yaml
+++ b/.github/workflows/activate-docker-distribution.yaml
@@ -67,19 +67,29 @@ jobs:
             exit 1
           fi
 
-      - name: "Update image tag"
+      - name: "Pull source image"
         run: |
           set +e
           docker pull "${{ env.IMAGE }}:${{ inputs.source_image_tag }}"
-          TAG="${{ env.IMAGE }}:${{ inputs.destination_image_tag }}"
 
-          if [[ ${{ inputs.set_latest }} ]]; then
-            TAG="${{ env.IMAGE }}:latest"
-          fi
+      - name: "Push image with latest tag if selected"
+        if: ${{ inputs.set_latest == true }}
+        run: |
+          set +e
+          docker pull "${{ env.IMAGE }}:${{ inputs.source_image_tag }}"
+          TAG="${{ env.IMAGE }}:latest
           docker image tag "${{ env.IMAGE }}:${{ inputs.source_image_tag }}" $TAG
-
           docker push $TAG
-          if [[ ${{ inputs.delete_source }} ]]; then
-            TOKEN=`curl -s -H "Content-Type: application/json" -X POST -d "{\"username\": \"${{ secrets.DOCKERHUB_USERNAME}}\", \"password\": \"${{ secrets.DOCKERHUB_TOKEN }}\"}" "https://hub.docker.com/v2/users/login/" | jq -r .token`
-            curl "https://hub.docker.com/v2/repositories/concordium/${{ inputs.environment }}/tags/${{ env.IMAGE }}:${{ inputs.source_image_tag }}/" -X DELETE -H "Authorization: JWT $TOKEN"
-          fi
+
+      - name: "Update image tag"
+        run: |
+          set +e
+          TAG="${{ env.IMAGE }}:${{ inputs.destination_image_tag }}"
+          docker image tag "${{ env.IMAGE }}:${{ inputs.source_image_tag }}" $TAG
+          docker push $TAG
+
+      - name: "Delete source image if selected"
+        if: ${{ inputs.delete_source == true }}
+        run: |
+          TOKEN=`curl -s -H "Content-Type: application/json" -X POST -d "{\"username\": \"${{ secrets.DOCKERHUB_USERNAME}}\", \"password\": \"${{ secrets.DOCKERHUB_TOKEN }}\"}" "https://hub.docker.com/v2/users/login/" | jq -r .token`
+          curl "https://hub.docker.com/v2/repositories/concordium/${{ inputs.environment }}/tags/${{ env.IMAGE }}:${{ inputs.source_image_tag }}/" -X DELETE -H "Authorization: JWT $TOKEN"

--- a/.github/workflows/activate-docker-distribution.yaml
+++ b/.github/workflows/activate-docker-distribution.yaml
@@ -81,7 +81,8 @@ jobs:
           docker image tag "${{ env.IMAGE }}:${{ inputs.source_image_tag }}" $TAG
           docker push $TAG
 
-      - name: "Update image tag"
+      - name: "Create new tag from user input"
+        if: ${{ inputs.destination_image_tag != false }}
         run: |
           set +e
           TAG="${{ env.IMAGE }}:${{ inputs.destination_image_tag }}"

--- a/.github/workflows/activate-docker-distribution.yaml
+++ b/.github/workflows/activate-docker-distribution.yaml
@@ -77,7 +77,7 @@ jobs:
         run: |
           set +e
           docker pull "${{ env.IMAGE }}:${{ inputs.source_image_tag }}"
-          TAG="${{ env.IMAGE }}:latest
+          TAG="${{ env.IMAGE }}:latest"
           docker image tag "${{ env.IMAGE }}:${{ inputs.source_image_tag }}" $TAG
           docker push $TAG
 


### PR DESCRIPTION
Looks to me like the conditional in the job previously replaced the user-provided 'destination' tag with `latest` if the option to add a `latest` tag was selected when triggering the job.

This breaks the 'latest' and 'delete previous tag' sections out into seperate steps in the workflow to make it clear at a glance which actions were carried out. 