### PR TITLE
fix: display user input in summary

### DIFF
--- a/.github/workflows/activate-docker-distribution.yaml
+++ b/.github/workflows/activate-docker-distribution.yaml
@@ -1,5 +1,5 @@
 name: Activate docker distribution
-run-name: Creating Docker tag ${{ inputs.destination_image_tag }} (source: ${{ inputs.source_image_tag }})
+run-name: Creating Docker tag ${{ inputs.destination_image_tag }} from source ${{ inputs.source_image_tag }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/activate-docker-distribution.yaml
+++ b/.github/workflows/activate-docker-distribution.yaml
@@ -31,6 +31,20 @@ env:
   IMAGE: "concordium/${{ inputs.environment }}-node"
 
 jobs:
+  # This workflow needs approval - let's make it so a reviewer can see the input parameters.
+  print-input-params:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install jq
+        run : |
+          apt update
+          apt install -y jq
+      - name: Display parameters this workflow was called with
+        shell: bash
+        run:
+          printf '|Parameter|Value|\n|------|------|\n' >> $GITHUB_STEP_SUMMARY &&
+          jq -r 'to_entries | map("|\(.key)|\(.value)|") | join("\n") | @text' <<< '${{tojson(inputs)}}' | sed 's/\\n/\n/g' >> $GITHUB_STEP_SUMMARY
+
   update-docker-tag:
     runs-on: ubuntu-latest
     environment: rename-tags

--- a/.github/workflows/activate-docker-distribution.yaml
+++ b/.github/workflows/activate-docker-distribution.yaml
@@ -1,4 +1,5 @@
 name: Activate docker distribution
+run-name: Creating Docker tag ${{ inputs.destination_image_tag }} (source: ${{ inputs.source_image_tag }})
 
 on:
   workflow_dispatch:
@@ -37,8 +38,8 @@ jobs:
     steps:
       - name: Install jq
         run : |
-          apt update
-          apt install -y jq
+          sudo apt update
+          sudo apt install -y jq
       - name: Display parameters this workflow was called with
         shell: bash
         run:
@@ -55,7 +56,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: "Check Source image tag"
+      - name: "Checking source tag ${{ inputs.source_image_tag }} exists"
         run: |
           set +e
           docker manifest inspect "${{ env.IMAGE }}:${{ inputs.source_image_tag }}"
@@ -68,7 +69,7 @@ jobs:
             exit 1
           fi
 
-      - name: "Check destination image tag"
+      - name: "Checking destination tag ${{ inputs.destination_image_tag }} does not already exist"
         run: |
           set +e
           docker manifest inspect "${{ env.IMAGE }}:${{ inputs.destination_image_tag }}"


### PR DESCRIPTION
It seems like there isn't a way to show the provided user inputs in the Github UI without adding a step to the job to somehow log them: https://github.com/orgs/community/discussions/8303

This adds a job to write them to the step summary outside the `rename-tags` environment so it's possible for a reviewer to check the tag names are appropriate.
