### PR TITLE
fix: jq is already on the runner image no need to install

### DIFF
--- a/.github/workflows/activate-docker-distribution.yaml
+++ b/.github/workflows/activate-docker-distribution.yaml
@@ -36,10 +36,6 @@ jobs:
   print-input-params:
     runs-on: ubuntu-latest
     steps:
-      - name: Install jq
-        run : |
-          sudo apt update
-          sudo apt install -y jq
       - name: Display parameters this workflow was called with
         shell: bash
         run:


### PR DESCRIPTION
Just removing this step to save a second or two on runtime. 

We can see it's already present on the runner image in logs from previous run: https://github.com/Concordium/concordium-infra-images/actions/runs/17555732616/job/49859273012

```
Reading package lists...
Building dependency tree...
Reading state information...
jq is already the newest version (1.7.1-3ubuntu0.24.04.1).
0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.
```