### PR TITLE
upgrading rust version to match with node repo release yaml

### DIFF
--- a/.github/workflows/release-static-libraries.yaml
+++ b/.github/workflows/release-static-libraries.yaml
@@ -10,7 +10,7 @@ jobs:
       SERVICE_NAME: "static-libraries"
       BUILD_ARGS: |
         UBUNTU_VERSION=20.04
-        RUST_VERSION=1.82
+        RUST_VERSION=1.94
         GHC_VERSION=9.10.2
         STACK_VERSION=3.1.1
         PROTOC_VERSION=28.3


### PR DESCRIPTION
## Purpose
concordium-node repo, release.yaml now has RUST_VERSION set to 1.94 and the STATIC_LIBRARIES_IMAGE_TAG: 'rust-1.94_ghc-9.10.2'

## Changes
Setting this rust version to be 1.94 in release-static-libraries.yaml, so we have rust version in sync.


## Checklist

- [ x ] My code follows the style of this project.
- [ x ] The code compiles without warnings.
- [ x ] I have performed a self-review of the changes.
- [ x ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
